### PR TITLE
버튼 수정

### DIFF
--- a/src/components/ui/button.stories.ts
+++ b/src/components/ui/button.stories.ts
@@ -18,7 +18,11 @@ const meta = {
   argTypes: {
     variant: {
       control: 'select',
-      options: ['primary', 'secondary', 'outline'],
+      options: ['primary', 'secondary', 'outline', 'deactivation', 'secondary'],
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'lg', 'icon'],
     },
   },
   // Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#action-args
@@ -41,5 +45,23 @@ export const Secondary: Story = {
     variant: 'outline',
     children: 'asdasd',
     asChild: false,
+  },
+};
+
+export const Deactivation: Story = {
+  args: {
+    variant: 'deactivation',
+    children: '가입하기',
+    asChild: false,
+    size: 'lg',
+  },
+};
+
+export const Deactivation3: Story = {
+  args: {
+    variant: 'secondary',
+    children: '나의 데이터 등록하기',
+    asChild: false,
+    size: 'lg',
   },
 };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,26 +5,27 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "cursor-pointer inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
-        default:
-          'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',
+        default: 'bg-primary text-primary-foreground',
         destructive:
-          'bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+          'bg-destructive text-white focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
         outline:
-          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
+          'border bg-background dark:bg-input/30 dark:border-input text-[var(--gray-5)]',
         secondary:
-          'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
+          'border border-primary bg-background dark:bg-input/30 text-primary',
+        deactivation:
+          'border bg-[var(--gray-2)] text-[var(--white)] dark:bg-input/30 dark:border-input',
         ghost:
           'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
         link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
+        default: 'h-12.5 px-4 py-2 has-[>svg]:px-3',
         sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
-        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+        lg: 'h-14.5 rounded-md px-6 has-[>svg]:px-4',
         icon: 'size-9',
       },
     },


### PR DESCRIPTION
사용 안하는 버튼 스타일은 PR 설명란에 (❌) 표시 해두었습니다.

`default` : 기본버튼 스타일
`destructive` : 경고 버튼 (❌)
`outline` : gray 테두리 + gray 글자색 만 있는 버튼
`secondary` : primary 테두리 + primary 글씨의 보조 버튼
`deactivation` : 비활성화 버튼 (흰 글씨의 gray02 배경)
`ghost` : 마우스 호버시 배경만 생기는 버튼 (❌)
`link`: 텍스트 링크 형태의 버튼 (❌)